### PR TITLE
Removing the master and slave words

### DIFF
--- a/Tools/Scripts/pycordexer/docs/conf.py
+++ b/Tools/Scripts/pycordexer/docs/conf.py
@@ -45,8 +45,8 @@ templates_path = ['_templates']
 # source_suffix = ['.rst', '.md']
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'PyCordexer'
@@ -142,7 +142,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'PyCordexer.tex', 'PyCordexer Documentation',
+    (main_doc, 'PyCordexer.tex', 'PyCordexer Documentation',
      'eXact-lab', 'manual'),
 ]
 
@@ -152,7 +152,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'pycordexer', 'PyCordexer Documentation',
+    (main_doc, 'pycordexer', 'PyCordexer Documentation',
      [author], 1)
 ]
 
@@ -163,7 +163,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'PyCordexer', 'PyCordexer Documentation',
+    (main_doc, 'PyCordexer', 'PyCordexer Documentation',
      author, 'PyCordexer', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/Tools/Scripts/pycordexer/pycordexer.py
+++ b/Tools/Scripts/pycordexer/pycordexer.py
@@ -427,8 +427,8 @@ def main():
     )
     collect_logs()
 
-    LOGGER.debug('Building a pool of slave processes to perform elaborations')
-    worker_pool = Pool(max_num_of_process=args.processes, name='Slave')
+    LOGGER.debug('Building a pool of subordinate processes to perform elaborations')
+    worker_pool = Pool(max_num_of_process=args.processes, name='Subordinate')
 
     if args.disable_corrflag:
         corrflag = False

--- a/Tools/Scripts/regcm_postproc-0.0.1/conf.py
+++ b/Tools/Scripts/regcm_postproc-0.0.1/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'RegCM postprocessing tool'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.